### PR TITLE
add javafx support for oracle-java/jdk-8

### DIFF
--- a/oracle-java/jdk-8/Dockerfile
+++ b/oracle-java/jdk-8/Dockerfile
@@ -33,22 +33,11 @@ RUN apk upgrade --update && \
     rm -rf "$JAVA_HOME/"*src.zip \
            "$JAVA_HOME/lib/missioncontrol" \
            "$JAVA_HOME/lib/visualvm" \
-           "$JAVA_HOME/lib/"*javafx* \
-           "$JAVA_HOME/jre/lib/ext/jfxrt.jar" \
            "$JAVA_HOME/jre/bin/javaws" \
            "$JAVA_HOME/jre/lib/javaws.jar" \
            "$JAVA_HOME/jre/lib/desktop" \
            "$JAVA_HOME/jre/plugin" \
            "$JAVA_HOME/jre/lib/"deploy* \
-           "$JAVA_HOME/jre/lib/"*javafx* \
-           "$JAVA_HOME/jre/lib/"*jfx* \
-           "$JAVA_HOME/jre/lib/amd64/libdecora_sse.so" \
-           "$JAVA_HOME/jre/lib/amd64/"libprism_*.so \
-           "$JAVA_HOME/jre/lib/amd64/libfxplugins.so" \
-           "$JAVA_HOME/jre/lib/amd64/libglass.so" \
-           "$JAVA_HOME/jre/lib/amd64/libgstreamer-lite.so" \
-           "$JAVA_HOME/jre/lib/amd64/"libjavafx*.so \
-           "$JAVA_HOME/jre/lib/amd64/"libjfx*.so \
            "$JAVA_HOME/jre/bin/jjs" \
            "$JAVA_HOME/jre/bin/keytool" \
            "$JAVA_HOME/jre/bin/orbd" \


### PR DESCRIPTION
**Motivation:**
Projects that use JavaFX packages can not be compiled using this image.

**Solution:**
Do not remove JavaFX-specific libraries (which can be listed [here](http://www.oracle.com/technetwork/java/javase/jre-8-readme-2095710.html)) after the JDK installation.
