### PR TITLE
Updates tomcat 7, 8 and 8.5

### DIFF
--- a/repos/tomcat/opts.yml
+++ b/repos/tomcat/opts.yml
@@ -1,6 +1,6 @@
-tomcat_85_latest: &tomcat_85_latest 8.5.20
-tomcat_8_latest: &tomcat_8_latest 8.0.46
-tomcat_7_latest: &tomcat_7_latest 7.0.81
+tomcat_85_latest: &tomcat_85_latest 8.5.23
+tomcat_8_latest: &tomcat_8_latest 8.0.47
+tomcat_7_latest: &tomcat_7_latest 7.0.82
 tomcat_6_latest: &tomcat_6_latest 6.0.53
 
 tags:
@@ -15,13 +15,13 @@ tags:
 aliases:
   latest: 8.5
   8.5: 8.5-jdk8
-  8.5.20-jdk8: 8.5-jdk8
+  8.5.23-jdk8: 8.5-jdk8
   8: 8-jdk8
-  8.0.46-jdk8: 8-jdk8
-  8.0.46-jdk7: 8-jdk7
+  8.0.47-jdk8: 8-jdk8
+  8.0.47-jdk7: 8-jdk7
   7: 7-jdk8
-  7.0.81-jdk8: 7-jdk8
-  7.0.81-jdk7: 7-jdk7
+  7.0.82-jdk8: 7-jdk8
+  7.0.82-jdk7: 7-jdk7
   6: 6-jdk7
   6.0.53-jdk7: 6-jdk7
   6.0.53-jdk6: 6-jdk6

--- a/tomcat/7-jdk7/Dockerfile
+++ b/tomcat/7-jdk7/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Andre Albino Pereira <andreptb@gmail.com>
 ENV CATALINA_HOME="/usr/local/tomcat" \
     PATH="/usr/local/tomcat/bin:$PATH" \
     TOMCAT_MAJOR_VERSION=7 \
-    TOMCAT_MINOR_VERSION=7.0.81 \
+    TOMCAT_MINOR_VERSION=7.0.82 \
     APACHE_MIRROR="https://archive.apache.org/dist" \
     APR_VERSION=1.6.2 \
     TOMCAT_NATIVE_VERSION=1.2.14

--- a/tomcat/7-jdk8/Dockerfile
+++ b/tomcat/7-jdk8/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Andre Albino Pereira <andreptb@gmail.com>
 ENV CATALINA_HOME="/usr/local/tomcat" \
     PATH="/usr/local/tomcat/bin:$PATH" \
     TOMCAT_MAJOR_VERSION=7 \
-    TOMCAT_MINOR_VERSION=7.0.81 \
+    TOMCAT_MINOR_VERSION=7.0.82 \
     APACHE_MIRROR="https://archive.apache.org/dist" \
     APR_VERSION=1.6.2 \
     TOMCAT_NATIVE_VERSION=1.2.14

--- a/tomcat/8-jdk7/Dockerfile
+++ b/tomcat/8-jdk7/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Andre Albino Pereira <andreptb@gmail.com>
 ENV CATALINA_HOME="/usr/local/tomcat" \
     PATH="/usr/local/tomcat/bin:$PATH" \
     TOMCAT_MAJOR_VERSION=8 \
-    TOMCAT_MINOR_VERSION=8.0.46 \
+    TOMCAT_MINOR_VERSION=8.0.47 \
     APACHE_MIRROR="https://archive.apache.org/dist" \
     APR_VERSION=1.6.2 \
     TOMCAT_NATIVE_VERSION=1.2.14

--- a/tomcat/8-jdk8/Dockerfile
+++ b/tomcat/8-jdk8/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Andre Albino Pereira <andreptb@gmail.com>
 ENV CATALINA_HOME="/usr/local/tomcat" \
     PATH="/usr/local/tomcat/bin:$PATH" \
     TOMCAT_MAJOR_VERSION=8 \
-    TOMCAT_MINOR_VERSION=8.0.46 \
+    TOMCAT_MINOR_VERSION=8.0.47 \
     APACHE_MIRROR="https://archive.apache.org/dist" \
     APR_VERSION=1.6.2 \
     TOMCAT_NATIVE_VERSION=1.2.14

--- a/tomcat/8.5-jdk8/Dockerfile
+++ b/tomcat/8.5-jdk8/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Andre Albino Pereira <andreptb@gmail.com>
 ENV CATALINA_HOME="/usr/local/tomcat" \
     PATH="/usr/local/tomcat/bin:$PATH" \
     TOMCAT_MAJOR_VERSION=8 \
-    TOMCAT_MINOR_VERSION=8.5.20 \
+    TOMCAT_MINOR_VERSION=8.5.23 \
     APACHE_MIRROR="https://archive.apache.org/dist" \
     APR_VERSION=1.6.2 \
     TOMCAT_NATIVE_VERSION=1.2.14

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -1,10 +1,10 @@
 # Supported tags and respective `Dockerfile` links
 
-- [`8.5-jdk8`, `8.5`, `latest`, `8.5.20-jdk8` (*8.5-jdk8/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/8.5-jdk8/Dockerfile)
-- [`8-jdk7`, `8.0.46-jdk7` (*8-jdk7/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/8-jdk7/Dockerfile)
-- [`8-jdk8`, `8`, `8.0.46-jdk8` (*8-jdk8/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/8-jdk8/Dockerfile)
-- [`7-jdk7`, `7.0.81-jdk7` (*7-jdk7/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/7-jdk7/Dockerfile)
-- [`7-jdk8`, `7`, `7.0.81-jdk8` (*7-jdk8/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/7-jdk8/Dockerfile)
+- [`8.5-jdk8`, `8.5`, `latest`, `8.5.23-jdk8` (*8.5-jdk8/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/8.5-jdk8/Dockerfile)
+- [`8-jdk7`, `8.0.47-jdk7` (*8-jdk7/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/8-jdk7/Dockerfile)
+- [`8-jdk8`, `8`, `8.0.47-jdk8` (*8-jdk8/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/8-jdk8/Dockerfile)
+- [`7-jdk7`, `7.0.82-jdk7` (*7-jdk7/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/7-jdk7/Dockerfile)
+- [`7-jdk8`, `7`, `7.0.82-jdk8` (*7-jdk8/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/7-jdk8/Dockerfile)
 - [`6-jdk6`, `6.0.53-jdk6` (*6-jdk6/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/6-jdk6/Dockerfile)
 - [`6-jdk7`, `6`, `6.0.53-jdk7` (*6-jdk7/Dockerfile*)](https://github.com/andreptb/Dockerfiles/blob/master/tomcat/6-jdk7/Dockerfile)
 


### PR DESCRIPTION
Updates tomcat versions to the most recent available in 19/10/2017:

* tomcat-7.0.82
* tomcat-8.0.47
* tomcat-8.5.23